### PR TITLE
Fix "dyld: Library not loaded" problems on macosx.

### DIFF
--- a/.build_dependencies
+++ b/.build_dependencies
@@ -11,18 +11,23 @@ absolute_path(){
    done
    echo $retval
 }
- 
+
 wget http://mpir.org/mpir-2.7.2.tar.bz2
 tar -xf mpir-2.7.2.tar.bz2
+mkdir -p local
+
 cd mpir-2.7.2
-./configure ABI=$ABI --enable-gmpcompat
-${MAKE} > /dev/null 2>&1
+./configure ABI=$ABI --enable-gmpcompat --prefix=$(absolute_path "../local")
+${MAKE}  > /dev/null 2>&1
+${MAKE} install  > /dev/null 2>&1
+
 cd ..
 wget http://www.mpfr.org/mpfr-4.0.0/mpfr-4.0.0.tar.bz2
 tar -xf mpfr-4.0.0.tar.bz2
 cd mpfr-4.0.0
-./configure ABI=$ABI --with-gmp-build=$(absolute_path "../mpir-2.7.2")
-${MAKE} > /dev/null 2>&1
+./configure ABI=$ABI --with-gmp=$(absolute_path "../local") --prefix=$(absolute_path "../local")
+${MAKE}  > /dev/null 2>&1
+${MAKE} install  > /dev/null 2>&1
 cd ..
  
 echo "int flint_test_multiplier(){return 1;}" > test_helpers.c

--- a/.build_dependencies
+++ b/.build_dependencies
@@ -18,16 +18,16 @@ mkdir -p local
 
 cd mpir-2.7.2
 ./configure ABI=$ABI --enable-gmpcompat --prefix=$(absolute_path "../local")
-${MAKE}  > /dev/null 2>&1
-${MAKE} install  > /dev/null 2>&1
+${MAKE} > /dev/null 2>&1
+${MAKE} install > /dev/null 2>&1
 
 cd ..
 wget http://www.mpfr.org/mpfr-4.0.0/mpfr-4.0.0.tar.bz2
 tar -xf mpfr-4.0.0.tar.bz2
 cd mpfr-4.0.0
 ./configure ABI=$ABI --with-gmp=$(absolute_path "../local") --prefix=$(absolute_path "../local")
-${MAKE}  > /dev/null 2>&1
-${MAKE} install  > /dev/null 2>&1
+${MAKE} > /dev/null 2>&1
+${MAKE} install > /dev/null 2>&1
 cd ..
  
 echo "int flint_test_multiplier(){return 1;}" > test_helpers.c

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,12 @@ compiler:
 
 install:
   - ./.build_dependencies
-  - ./configure --with-mpir=local --with-mpfr=local --prefix=`pwd`
+  - ./configure --with-mpir=local --with-mpfr=local --prefix=local
   - ${MAKE} QUIET_CC=
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then otool -L libflint.dylib; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ldd libflint.so; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make install; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then otool -L local/lib/libflint.dylib; fi
 
 script:
   - ${MAKE} check QUIET_CC=

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ install:
   - ${MAKE} QUIET_CC=
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then otool -L libflint.dylib; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ldd libflint.so; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make install; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then otool -L local/lib/libflint.dylib; fi
 
 script:
   - ${MAKE} check QUIET_CC=
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ${MAKE} install; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then otool -L local/lib/libflint.dylib; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ compiler:
 
 install:
   - ./.build_dependencies
-  - ./configure --with-mpir=mpir-2.7.2 --with-mpfr=mpfr-4.0.0
+  - ./configure --with-mpir=local --with-mpfr=local --prefix=`pwd`
   - ${MAKE} QUIET_CC=
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then otool -L libflint.dylib; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ldd libflint.so; fi

--- a/Makefile.in
+++ b/Makefile.in
@@ -210,6 +210,9 @@ install: library
 	mkdir -p "$(DESTDIR)$(PREFIX)/include/flint/flintxx"
 	cp flintxx/*.h "$(DESTDIR)$(PREFIX)/include/flint/flintxx"
 	cp *xx.h "$(DESTDIR)$(PREFIX)/include/flint"
+	if [[ "$(OS)" = "Darwin" ]]; then \
+        install_name_tool -id "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(FLINT_LIB)" "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(FLINT_LIBNAME)"; \
+    fi
 
 build:
 	mkdir -p build

--- a/Makefile.in
+++ b/Makefile.in
@@ -210,7 +210,7 @@ install: library
 	mkdir -p "$(DESTDIR)$(PREFIX)/include/flint/flintxx"
 	cp flintxx/*.h "$(DESTDIR)$(PREFIX)/include/flint/flintxx"
 	cp *xx.h "$(DESTDIR)$(PREFIX)/include/flint"
-	if [[ "$(OS)" = "Darwin" ]]; then \
+	if [ "$(OS)" = "Darwin" ]; then \
     		install_name_tool -id "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(FLINT_LIB)" "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(FLINT_LIBNAME)"; \
 	fi
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -211,8 +211,8 @@ install: library
 	cp flintxx/*.h "$(DESTDIR)$(PREFIX)/include/flint/flintxx"
 	cp *xx.h "$(DESTDIR)$(PREFIX)/include/flint"
 	if [[ "$(OS)" = "Darwin" ]]; then \
-        install_name_tool -id "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(FLINT_LIB)" "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(FLINT_LIBNAME)"; \
-    fi
+    		install_name_tool -id "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(FLINT_LIB)" "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(FLINT_LIBNAME)"; \
+	fi
 
 build:
 	mkdir -p build

--- a/configure
+++ b/configure
@@ -473,6 +473,7 @@ if [ -z "$FLINT_LIB" ]; then
       Darwin)
          FLINT_LIBNAME="libflint.dylib"
          FLINT_LIB="libflint-$FLINT_MAJOR.dylib"
+         EXTRA_SHARED_FLAGS="-install_name $PREFIX/$FLINT_LIB"
          EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -compatibility_version $FLINT_MAJOR.$FLINT_MINOR"
          EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -current_version $FLINT_MAJOR.$FLINT_MINOR.$FLINT_PATCH"
          ;;

--- a/configure
+++ b/configure
@@ -150,7 +150,7 @@ while [ "$1" != "" ]; do
          BUILD="$VALUE"
          ;;
       --prefix)
-         PREFIX=$VALUE
+         PREFIX=$(absolute_path "$VALUE")
          ;;
       --enable-shared)
          SHARED=1
@@ -473,7 +473,7 @@ if [ -z "$FLINT_LIB" ]; then
       Darwin)
          FLINT_LIBNAME="libflint.dylib"
          FLINT_LIB="libflint-$FLINT_MAJOR.dylib"
-         EXTRA_SHARED_FLAGS="-install_name $PREFIX/$FLINT_LIB"
+         EXTRA_SHARED_FLAGS="-install_name `pwd`/$FLINT_LIB"
          EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -compatibility_version $FLINT_MAJOR.$FLINT_MINOR"
          EXTRA_SHARED_FLAGS="$EXTRA_SHARED_FLAGS -current_version $FLINT_MAJOR.$FLINT_MINOR.$FLINT_PATCH"
          ;;
@@ -758,6 +758,7 @@ echo "FLINT_STATIC=$STATIC" >> Makefile
 echo "FLINT_SHARED=$SHARED" >> Makefile
 echo "FLINT_LIB=$FLINT_LIB" >> Makefile
 echo "FLINT_LIBNAME=$FLINT_LIBNAME" >> Makefile
+echo "OS=$OS" >> Makefile
 echo "FLINT_SOLIB=$FLINT_SOLIB" >> Makefile
 echo "FLINT_MAJOR=$FLINT_MAJOR" >> Makefile
 echo "EXEEXT=$EXEEXT" >> Makefile


### PR DESCRIPTION
set a "--prefix" when calling configure for libflint mpfr and mpir
add an "-install_name" flag for libflint
define an install path for mpfr and mpir in .build_dependencies file